### PR TITLE
ANDROID: Fix eDP backlight brightness issue

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_panel.c
+++ b/drivers/gpu/drm/i915/display/intel_panel.c
@@ -1169,6 +1169,7 @@ static void __intel_panel_enable_backlight(const struct intel_crtc_state *crtc_s
 	WARN_ON(panel->backlight.max == 0);
 
 	if (panel->backlight.level <= panel->backlight.min) {
+		panel->backlight.level = panel->backlight.max;
 		if (panel->backlight.device)
 			panel->backlight.device->props.brightness =
 				scale_hw_to_user(connector,


### PR DESCRIPTION
Current kernel miss the brightness set for eDP backlight, so
add this back to ensure Android UI show up on eDP panel.

Tracked-On: OAM-91286
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>