### PR TITLE
drm/i915/gvt: [REVERTME] avoid acrn hv emulation fault when accessing…

### DIFF
--- a/arch/x86/kernel/apic/ipi.c
+++ b/arch/x86/kernel/apic/ipi.c
@@ -103,7 +103,9 @@ static inline int __prepare_ICR2(unsigned int mask)
 
 static inline void __xapic_wait_icr_idle(void)
 {
-	while (native_apic_mem_read(APIC_ICR) & APIC_ICR_BUSY)
+	int count=100;
+
+	while(count-- > 0)
 		cpu_relax();
 }
 


### PR DESCRIPTION
… APIC_ICR

When guest OS accesses the APCI_IRC register, the acrn hypervisor failed to
do expected emulation. This patch is a workaround and formal patch will be made
in hypervior domain.

Tracked-On:
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>