### PR TITLE
drm/i915/gt: Schedule request retirement for gen10+

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_lrc.c
+++ b/drivers/gpu/drm/i915/gt/intel_lrc.c
@@ -1272,13 +1272,15 @@ __execlists_schedule_out(struct i915_request *rq,
 	 * refrain from doing non-trivial work here.
 	 */
 
-	/*
-	 * If we have just completed this context, the engine may now be
-	 * idle and we want to re-enter powersaving.
-	 */
-	if (list_is_last(&rq->link, &ce->timeline->requests) &&
-	    i915_request_completed(rq))
-		intel_engine_add_retire(engine, ce->timeline);
+	if (INTEL_GEN(engine->i915) >= 10) {
+		/*
+		 * If we have just completed this context, the engine
+		 * may now be idle and we want to re-enter powersaving.
+		 */
+		if (list_is_last(&rq->link, &ce->timeline->requests) &&
+		    i915_request_completed(rq))
+			intel_engine_add_retire(engine, ce->timeline);
+	}
 
 	intel_engine_context_out(engine);
 	execlists_context_status_change(rq, INTEL_CONTEXT_SCHEDULE_OUT);


### PR DESCRIPTION
In CML, "Schedule request retirement when timeline idles" might
introduce random drm init failure during reboot. This change is
to enable schedule request retirement on Gen10+

Signed-off-by: Romli, Khairul Anuar <khairul.anuar.romli@intel.com>
Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>