### PR TITLE
x86/e820: fix the function type for e820__mapped_all

### DIFF
--- a/arch/x86/include/asm/e820/api.h
+++ b/arch/x86/include/asm/e820/api.h
@@ -12,7 +12,7 @@ extern unsigned long pci_mem_start;
 
 extern bool e820__mapped_raw_any(u64 start, u64 end, enum e820_type type);
 extern bool e820__mapped_any(u64 start, u64 end, enum e820_type type);
-extern bool e820__mapped_all(u64 start, u64 end, enum e820_type type);
+extern bool e820__mapped_all(u64 start, u64 end, unsigned type);
 
 extern void e820__range_add   (u64 start, u64 size, enum e820_type type);
 extern u64  e820__range_update(u64 start, u64 size, enum e820_type old_type, enum e820_type new_type);

--- a/arch/x86/kernel/e820.c
+++ b/arch/x86/kernel/e820.c
@@ -145,7 +145,7 @@ static struct e820_entry *__e820__mapped_all(u64 start, u64 end,
 /*
  * This function checks if the entire range <start,end> is mapped with type.
  */
-bool __init e820__mapped_all(u64 start, u64 end, enum e820_type type)
+bool __init e820__mapped_all(u64 start, u64 end, unsigned type)
 {
 	return __e820__mapped_all(start, end, type);
 }


### PR DESCRIPTION
e820__mapped_all is passed as a callback to is_mmconf_reserved, which
expects a function of type:

  typedef bool (*check_reserved_t)(u64 start, u64 end, unsigned type);

This trips indirect call checking with Clang's Control-Flow Integrity
(CFI). Change the last argument from enum e820_type to unsigned to fix
the type mismatch.

Tracked-On: OAM-94510
Reported-by: Sedat Dilek <sedat.dilek@gmail.com>
Signed-off-by: Sami Tolvanen <samitolvanen@google.com>