### PR TITLE
Revert "ANDROID: security,perf: Allow further restriction of perf_eve…

### DIFF
--- a/Documentation/admin-guide/sysctl/kernel.rst
+++ b/Documentation/admin-guide/sysctl/kernel.rst
@@ -721,8 +721,7 @@ perf_event_paranoid:
 ====================
 
 Controls use of the performance events system by unprivileged
-users (without CAP_SYS_ADMIN).  The default value is 3 if
-CONFIG_SECURITY_PERF_EVENTS_RESTRICT is set, or 2 otherwise.
+users (without CAP_SYS_ADMIN).  The default value is 2.
 
 ===  ==================================================================
  -1  Allow use of (almost) all events by all users
@@ -736,8 +735,6 @@ CONFIG_SECURITY_PERF_EVENTS_RESTRICT is set, or 2 otherwise.
 >=1  Disallow CPU event access by users without CAP_SYS_ADMIN
 
 >=2  Disallow kernel profiling by users without CAP_SYS_ADMIN
-
->=3: Disallow all event access by users without CAP_SYS_ADMIN
 ===  ==================================================================
 
 

--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -1241,11 +1241,6 @@ extern int perf_cpu_time_max_percent_handler(struct ctl_table *table, int write,
 int perf_event_max_stack_handler(struct ctl_table *table, int write,
 				 void __user *buffer, size_t *lenp, loff_t *ppos);
 
-static inline bool perf_paranoid_any(void)
-{
-	return sysctl_perf_event_paranoid > 2;
-}
-
 static inline bool perf_paranoid_tracepoint_raw(void)
 {
 	return sysctl_perf_event_paranoid > -1;

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -404,13 +404,8 @@ static cpumask_var_t perf_online_mask;
  *   0 - disallow raw tracepoint access for unpriv
  *   1 - disallow cpu events for unpriv
  *   2 - disallow kernel profiling for unpriv
- *   3 - disallow all unpriv perf event use
  */
-#ifdef CONFIG_SECURITY_PERF_EVENTS_RESTRICT
-int sysctl_perf_event_paranoid __read_mostly = 3;
-#else
 int sysctl_perf_event_paranoid __read_mostly = 2;
-#endif
 
 /* Minimum for 512 kiB + 1 user control page */
 int sysctl_perf_event_mlock __read_mostly = 512 + (PAGE_SIZE / 1024); /* 'free' kiB per user */
@@ -10928,9 +10923,6 @@ int ksys_perf_event_open(struct perf_event_attr __user * attr_uptr, pid_t pid,
 	/* for future expandability... */
 	if (flags & ~PERF_FLAG_ALL)
 		return -EINVAL;
-
-	if (perf_paranoid_any() && !capable(CAP_SYS_ADMIN))
-		return -EACCES;
 
 	err = perf_copy_attr(attr_uptr, &attr);
 	if (err)

--- a/security/Kconfig
+++ b/security/Kconfig
@@ -19,15 +19,6 @@ config SECURITY_DMESG_RESTRICT
 
 	  If you are unsure how to answer this question, answer N.
 
-config SECURITY_PERF_EVENTS_RESTRICT
-	bool "Restrict unprivileged use of performance events"
-	depends on PERF_EVENTS
-	help
-	  If you say Y here, the kernel.perf_event_paranoid sysctl
-	  will be set to 3 by default, and no unprivileged use of the
-	  perf_event_open syscall will be permitted unless it is
-	  changed.
-
 config SECURITY
 	bool "Enable different security models"
 	depends on SYSFS


### PR DESCRIPTION
…nt_open"

This reverts commit 75883fc7ac075c0d060e924d3a2b1594a9628721.