### PR TITLE
Trusty: fix bug when using work_on_cpu

### DIFF
--- a/drivers/trusty/trusty-x86_64.c
+++ b/drivers/trusty/trusty-x86_64.c
@@ -73,6 +73,7 @@ struct trusty_x86_64_irq_s {
 		.vector = 0x21,
 		.action = &tmp_action,
 	},
+*/
 	{
 		.irq = 3,
 		.vector = 0x22,
@@ -83,21 +84,22 @@ struct trusty_x86_64_irq_s {
 		.vector = 0x23,
 		.action = &tmp_action,
 	},
-*/
 };
 
-static long trusty_smc8_binder(void *args)
-{
-	struct smc_ret8 *para = (struct smc_ret8*)args;
+struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
+			    unsigned long r2, unsigned long r3,
+			    unsigned long r4, unsigned long r5,
+			    unsigned long r6, unsigned long r7) {
+	struct smc_ret8 para = {r0, r1, r2, r3, r4, r5, r6, r7};
 	register unsigned long smc_id asm("rax") = IKGT_SMC_HC_ID;
-	register unsigned long arg0 asm("rdi") = para->r0;
-	register unsigned long arg1 asm("rsi") = para->r1;
-	register unsigned long arg2 asm("rdx") = para->r2;
-	register unsigned long arg3 asm("rcx") = para->r3;
-	register unsigned long arg4 asm("r8")  = para->r4;
-	register unsigned long arg5 asm("r9")  = para->r5;
-	register unsigned long arg6 asm("r10") = para->r6;
-	register unsigned long arg7 asm("r11") = para->r7;
+	register unsigned long arg0 asm("rdi") = para.r0;
+	register unsigned long arg1 asm("rsi") = para.r1;
+	register unsigned long arg2 asm("rdx") = para.r2;
+	register unsigned long arg3 asm("rcx") = para.r3;
+	register unsigned long arg4 asm("r8")  = para.r4;
+	register unsigned long arg5 asm("r9")  = para.r5;
+	register unsigned long arg6 asm("r10") = para.r6;
+	register unsigned long arg7 asm("r11") = para.r7;
 
 	__asm__ __volatile__ (
 			"vmcall\n\r"
@@ -107,25 +109,14 @@ static long trusty_smc8_binder(void *args)
 				"r" (arg4), "r" (arg5), "r" (arg6), "r" (arg7)
 			: "memory");
 
-	para->r0 = arg0;
-	para->r1 = arg1;
-	para->r2 = arg2;
-	para->r3 = arg3;
-	para->r4 = arg4;
-	para->r5 = arg5;
-	para->r6 = arg6;
-	para->r7 = arg7;
-
-	return 0;
-}
-
-struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
-			    unsigned long r2, unsigned long r3,
-			    unsigned long r4, unsigned long r5,
-			    unsigned long r6, unsigned long r7) {
-	struct smc_ret8 para = {r0, r1, r2, r3, r4, r5, r6, r7};
-
-	work_on_cpu(0, trusty_smc8_binder, (void *)&para);
+	para.r0 = arg0;
+	para.r1 = arg1;
+	para.r2 = arg2;
+	para.r3 = arg3;
+	para.r4 = arg4;
+	para.r5 = arg5;
+	para.r6 = arg6;
+	para.r7 = arg7;
 
 	return para;
 }

--- a/drivers/trusty/trusty-x86_64.c
+++ b/drivers/trusty/trusty-x86_64.c
@@ -13,6 +13,7 @@
 
 #define IKGT_SMC_HC_ID 0x74727500
 
+#ifdef TRUSTY_X86_OWNS_INTR
 static irqreturn_t stub_action(int cpl, void *dev_id)
 {
 	return IRQ_NONE;
@@ -67,13 +68,11 @@ struct trusty_x86_64_irq_s {
  * Comment out all IRQs which planed to be reserved, since CIV design is
  * different from Google Trusty IA solution design.
  */
-/*
 	{
 		.irq = 1,
 		.vector = 0x21,
 		.action = &tmp_action,
 	},
-*/
 	{
 		.irq = 3,
 		.vector = 0x22,
@@ -85,6 +84,7 @@ struct trusty_x86_64_irq_s {
 		.action = &tmp_action,
 	},
 };
+#endif
 
 struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
 			    unsigned long r2, unsigned long r3,
@@ -182,6 +182,7 @@ static void __exit trusty_x86_64_driver_exit(void)
 	platform_driver_unregister(&trusty_x86_64_driver);
 }
 
+#ifdef TRUSTY_X86_OWNS_INTR
 int trusty_x86_64_release_reserved_vector(unsigned int vector)
 {
 	int idx;
@@ -243,6 +244,7 @@ static int __init trusty_x86_64_irq_init(void)
 }
 
 core_initcall(trusty_x86_64_irq_init);
+#endif
 
 subsys_initcall(trusty_x86_64_driver_init);
 module_exit(trusty_x86_64_driver_exit);

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -857,6 +857,29 @@ static struct futex_pi_state *alloc_pi_state(void)
 	return pi_state;
 }
 
+static void pi_state_update_owner(struct futex_pi_state *pi_state,
+						  struct task_struct *new_owner)
+{
+	struct task_struct *old_owner = pi_state->owner;
+
+	lockdep_assert_held(&pi_state->pi_mutex.wait_lock);
+
+	if (old_owner) {
+                raw_spin_lock(&old_owner->pi_lock);
+		WARN_ON(list_empty(&pi_state->list));
+		list_del_init(&pi_state->list);
+		raw_spin_unlock(&old_owner->pi_lock);
+        }
+
+	if (new_owner) {
+	        raw_spin_lock(&new_owner->pi_lock);
+		WARN_ON(!list_empty(&pi_state->list));
+		list_add(&pi_state->list, &new_owner->pi_state_list);
+		pi_state->owner = new_owner;
+		raw_spin_unlock(&new_owner->pi_lock);
+	}
+}
+
 static void get_pi_state(struct futex_pi_state *pi_state)
 {
 	WARN_ON_ONCE(!refcount_inc_not_zero(&pi_state->refcount));
@@ -1613,26 +1636,15 @@ static int wake_futex_pi(u32 __user *uaddr, u32 uval, struct futex_pi_state *pi_
 			ret = -EINVAL;
 	}
 
-	if (ret)
-		goto out_unlock;
-
-	/*
-	 * This is a point of no return; once we modify the uval there is no
-	 * going back and subsequent operations must not fail.
-	 */
-
-	raw_spin_lock(&pi_state->owner->pi_lock);
-	WARN_ON(list_empty(&pi_state->list));
-	list_del_init(&pi_state->list);
-	raw_spin_unlock(&pi_state->owner->pi_lock);
-
-	raw_spin_lock(&new_owner->pi_lock);
-	WARN_ON(!list_empty(&pi_state->list));
-	list_add(&pi_state->list, &new_owner->pi_state_list);
-	pi_state->owner = new_owner;
-	raw_spin_unlock(&new_owner->pi_lock);
-
-	postunlock = __rt_mutex_futex_unlock(&pi_state->pi_mutex, &wake_q);
+	if (!ret) {
+	        /*
+		 * This is a point of no return; once we modified the uval
+		 * there is no going back and subsequent operations must
+		 * not fail.
+		 */
+		pi_state_update_owner(pi_state, new_owner);
+		postunlock = __rt_mutex_futex_unlock(&pi_state->pi_mutex, &wake_q);
+	}
 
 out_unlock:
 	raw_spin_unlock_irq(&pi_state->pi_mutex.wait_lock);
@@ -2580,19 +2592,7 @@ retry:
 	 * We fixed up user space. Now we need to fix the pi_state
 	 * itself.
 	 */
-	if (pi_state->owner != NULL) {
-		raw_spin_lock(&pi_state->owner->pi_lock);
-		WARN_ON(list_empty(&pi_state->list));
-		list_del_init(&pi_state->list);
-		raw_spin_unlock(&pi_state->owner->pi_lock);
-	}
-
-	pi_state->owner = newowner;
-
-	raw_spin_lock(&newowner->pi_lock);
-	WARN_ON(!list_empty(&pi_state->list));
-	list_add(&pi_state->list, &newowner->pi_state_list);
-	raw_spin_unlock(&newowner->pi_lock);
+	pi_state_update_owner(pi_state, newowner);
 	raw_spin_unlock_irq(&pi_state->pi_mutex.wait_lock);
 
 	return 0;

--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -993,6 +993,11 @@ static int sco_sock_getsockopt(struct socket *sock, int level, int optname,
 
 	case BT_SNDMTU:
 	case BT_RCVMTU:
+		if (sk->sk_state != BT_CONNECTED) {
+			err = -ENOTCONN;
+			break;
+		}
+
 		if (put_user(sco_pi(sk)->wbs_pkt_len, (u32 __user *)optval))
 			err = -EFAULT;
 		break;

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -999,8 +999,11 @@ static __poll_t vsock_poll(struct file *file, struct socket *sock,
 			mask |= EPOLLOUT | EPOLLWRNORM | EPOLLWRBAND;
 
 	} else if (sock->type == SOCK_STREAM) {
-		const struct vsock_transport *transport = vsk->transport;
+		const struct vsock_transport *transport;
+
 		lock_sock(sk);
+
+		transport = vsk->transport;
 
 		/* Listening sockets that have connections in their accept
 		 * queue can be read.
@@ -1084,9 +1087,10 @@ static int vsock_dgram_sendmsg(struct socket *sock, struct msghdr *msg,
 	err = 0;
 	sk = sock->sk;
 	vsk = vsock_sk(sk);
-	transport = vsk->transport;
 
 	lock_sock(sk);
+
+	transport = vsk->transport;
 
 	err = vsock_auto_bind(vsk);
 	if (err)
@@ -1548,9 +1552,10 @@ static int vsock_stream_setsockopt(struct socket *sock,
 	err = 0;
 	sk = sock->sk;
 	vsk = vsock_sk(sk);
-	transport = vsk->transport;
 
 	lock_sock(sk);
+
+	transport = vsk->transport;
 
 	switch (optname) {
 	case SO_VM_SOCKETS_BUFFER_SIZE:
@@ -1684,7 +1689,6 @@ static int vsock_stream_sendmsg(struct socket *sock, struct msghdr *msg,
 
 	sk = sock->sk;
 	vsk = vsock_sk(sk);
-	transport = vsk->transport;
 	total_written = 0;
 	err = 0;
 
@@ -1692,6 +1696,8 @@ static int vsock_stream_sendmsg(struct socket *sock, struct msghdr *msg,
 		return -EOPNOTSUPP;
 
 	lock_sock(sk);
+
+	transport = vsk->transport;
 
 	/* Callers should not provide a destination with stream sockets. */
 	if (msg->msg_namelen) {
@@ -1827,10 +1833,11 @@ vsock_stream_recvmsg(struct socket *sock, struct msghdr *msg, size_t len,
 
 	sk = sock->sk;
 	vsk = vsock_sk(sk);
-	transport = vsk->transport;
 	err = 0;
 
 	lock_sock(sk);
+
+	transport = vsk->transport;
 
 	if (!transport || sk->sk_state != TCP_ESTABLISHED) {
 		/* Recvmsg is supposed to return 0 if a peer performs an


### PR DESCRIPTION
Preivously, we bind SMC work on CPU 0 directly, it triggers workqueue
message:

BUG: sleeping function called from invalid context at
kernel/workqueue.c:2986

It caused by context switch from trusty to trusty-x86_64 module. To fix
this issue, we move work_on_cpu function call, which is used to bind work
on CPU, out of smc8 to trusty_std_call32.

Tracked-On: OAM-95850
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>