### PR TITLE
iwl7000: Vendor command support in iwl7000 driver

### DIFF
--- a/drivers/net/wireless/iwl7000/iwlwifi/iwl-vendor-cmd.h
+++ b/drivers/net/wireless/iwl7000/iwlwifi/iwl-vendor-cmd.h
@@ -135,6 +135,8 @@
  * @IWL_MVM_VENDOR_CMD_GEO_SAR_GET_TABLE: retrieves the full GEO SAR table.
  *	Contains a &IWL_MVM_VENDOR_ATTR_SAR_TABLE and a
  *	&IWL_MVM_VENDOR_ATTR_GEO_SAR_VER attributes.
+ *	@IWL_MVM_VENDOR_CMD_GET_FW_VERSION: Driver version
+ *	@IWL_MVM_VENDOR_CMD_GET_FW_VERSION: Firmware version
  */
 
 enum iwl_mvm_vendor_cmd {
@@ -192,6 +194,8 @@ enum iwl_mvm_vendor_cmd {
 	IWL_MVM_VENDOR_CMD_PPAG_GET_TABLE                       = 0x33,
 	IWL_MVM_VENDOR_CMD_SAR_GET_TABLE                        = 0x34,
 	IWL_MVM_VENDOR_CMD_GEO_SAR_GET_TABLE                    = 0x35,
+	IWL_MVM_VENDOR_CMD_GET_FW_VERSION                       = 0x36,
+	IWL_MVM_VENDOR_CMD_GET_DRV_VERSION                      = 0x37,
 };
 
 /**
@@ -895,6 +899,8 @@ enum iwl_vendor_sw_rfkill_state {
  *	iwl_vendor_sar_per_chain_geo_table.
  * @IWL_MVM_VNDOR_ATTR_GEO_SAR_VER: u32 attribute. Contains the GEO SAR
  *	table version
+ * @IWL_MVM_VENDOR_ATTR_DRV_VER: string attribute. Driver version
+ * @IWL_MVM_VENDOR_ATTR_FW_VER: string attribute. Firmware version
  *
  * @NUM_IWL_MVM_VENDOR_ATTR: number of vendor attributes
  * @MAX_IWL_MVM_VENDOR_ATTR: highest vendor attribute number
@@ -1015,6 +1021,8 @@ enum iwl_mvm_vendor_attr {
 	IWL_MVM_VENDOR_ATTR_SAR_VER                             = 0x75,
 	IWL_MVM_VENDOR_ATTR_GEO_SAR_TABLE                       = 0x76,
 	IWL_MVM_VENDOR_ATTR_GEO_SAR_VER                         = 0x77,
+	IWL_MVM_VENDOR_ATTR_FW_VER                              = 0x78,
+	IWL_MVM_VENDOR_ATTR_DRV_VER                             = 0x79,
 
 	NUM_IWL_MVM_VENDOR_ATTR,
 	MAX_IWL_MVM_VENDOR_ATTR = NUM_IWL_MVM_VENDOR_ATTR - 1,

--- a/drivers/net/wireless/iwl7000/iwlwifi/iwl-vendor-cmd.h
+++ b/drivers/net/wireless/iwl7000/iwlwifi/iwl-vendor-cmd.h
@@ -904,7 +904,7 @@ enum iwl_vendor_sw_rfkill_state {
  *
  * @NUM_IWL_MVM_VENDOR_ATTR: number of vendor attributes
  * @MAX_IWL_MVM_VENDOR_ATTR: highest vendor attribute number
-
+ *
  */
 enum iwl_mvm_vendor_attr {
 	__IWL_MVM_VENDOR_ATTR_INVALID				= 0x00,

--- a/drivers/net/wireless/iwl7000/iwlwifi/mvm/vendor-cmd.c
+++ b/drivers/net/wireless/iwl7000/iwlwifi/mvm/vendor-cmd.c
@@ -1,5 +1,5 @@
 // iSPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
-/*i
+/*
  * Copyright (C) 2012-2014, 2018-2021 Intel Corporation
  * Copyright (C) 2013-2015 Intel Mobile Communications GmbH
  * Copyright (C) 2016-2017 Intel Deutschland GmbH
@@ -14,7 +14,7 @@
 #include "fw/api/datapath.h"
 
 #include "iwl-io.h"
-#include "iwl-prph.h"iii
+#include "iwl-prph.h"
 
 static LIST_HEAD(device_list);
 static DEFINE_SPINLOCK(device_list_lock);
@@ -42,7 +42,7 @@ static int iwl_mvm_netlink_notifier(struct notifier_block *nb,
 static struct notifier_block iwl_mvm_netlink_notifier_block = {
 	.notifier_call = iwl_mvm_netlink_notifier,
 };
-i
+
 void iwl_mvm_vendor_cmd_init(void)
 {
 	WARN_ON(netlink_register_notifier(&iwl_mvm_netlink_notifier_block));
@@ -104,7 +104,7 @@ iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {
 	[IWL_MVM_VENDOR_ATTR_TIME_SYNC_T3] = { .type = NLA_U64 },
 	[IWL_MVM_VENDOR_ATTR_TIME_SYNC_T3_MAX_ERROR] = { .type = NLA_U32 },
 	[IWL_MVM_VENDOR_ATTR_ROAMING_FORBIDDEN] = { .type = NLA_U8 },
-	[IWL_MVM_VENDOR_ATTR_AUTH_MODE] = { .type = NLA_U32 },i
+	[IWL_MVM_VENDOR_ATTR_AUTH_MODE] = { .type = NLA_U32 },
 	[IWL_MVM_VENDOR_ATTR_CHANNEL_NUM] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_HOST_DISASSOC_TYPE] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_SSID] = { .type = NLA_BINARY,

--- a/drivers/net/wireless/iwl7000/iwlwifi/mvm/vendor-cmd.c
+++ b/drivers/net/wireless/iwl7000/iwlwifi/mvm/vendor-cmd.c
@@ -1,18 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
-/*
+// iSPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/*i
  * Copyright (C) 2012-2014, 2018-2021 Intel Corporation
  * Copyright (C) 2013-2015 Intel Mobile Communications GmbH
  * Copyright (C) 2016-2017 Intel Deutschland GmbH
  */
 #include <linux/etherdevice.h>
 #include <net/netlink.h>
+#include <linux/utsname.h>
+#include <linux/version.h>
 #include <net/mac80211.h>
 #include "mvm.h"
 #include "iwl-vendor-cmd.h"
 #include "fw/api/datapath.h"
 
 #include "iwl-io.h"
-#include "iwl-prph.h"
+#include "iwl-prph.h"iii
 
 static LIST_HEAD(device_list);
 static DEFINE_SPINLOCK(device_list_lock);
@@ -40,7 +42,7 @@ static int iwl_mvm_netlink_notifier(struct notifier_block *nb,
 static struct notifier_block iwl_mvm_netlink_notifier_block = {
 	.notifier_call = iwl_mvm_netlink_notifier,
 };
-
+i
 void iwl_mvm_vendor_cmd_init(void)
 {
 	WARN_ON(netlink_register_notifier(&iwl_mvm_netlink_notifier_block));
@@ -102,7 +104,7 @@ iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {
 	[IWL_MVM_VENDOR_ATTR_TIME_SYNC_T3] = { .type = NLA_U64 },
 	[IWL_MVM_VENDOR_ATTR_TIME_SYNC_T3_MAX_ERROR] = { .type = NLA_U32 },
 	[IWL_MVM_VENDOR_ATTR_ROAMING_FORBIDDEN] = { .type = NLA_U8 },
-	[IWL_MVM_VENDOR_ATTR_AUTH_MODE] = { .type = NLA_U32 },
+	[IWL_MVM_VENDOR_ATTR_AUTH_MODE] = { .type = NLA_U32 },i
 	[IWL_MVM_VENDOR_ATTR_CHANNEL_NUM] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_HOST_DISASSOC_TYPE] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_SSID] = { .type = NLA_BINARY,
@@ -111,6 +113,8 @@ iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {
 	[IWL_MVM_VENDOR_ATTR_BAND] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_COLLOC_CHANNEL] = { .type = NLA_U8 },
 	[IWL_MVM_VENDOR_ATTR_COLLOC_ADDR] = { .type = NLA_BINARY, .len = ETH_ALEN },
+	[IWL_MVM_VENDOR_ATTR_FW_VER] = { .type = NLA_STRING, .len = 50 },
+	[IWL_MVM_VENDOR_ATTR_DRV_VER] = { .type = NLA_STRING, .len = 50 },
 };
 
 static struct nlattr **iwl_mvm_parse_vendor_data(const void *data, int data_len)
@@ -1810,6 +1814,48 @@ free:
 	return err;
 }
 
+static int iwl_mvm_vendor_get_fw_version(struct wiphy *wiphy,
+				   struct wireless_dev *wdev,
+				   const void *data, int data_len)
+{
+	int err = 0;
+	struct sk_buff *skb;
+	struct ieee80211_hw *hw = wiphy_to_ieee80211_hw(wiphy);
+	struct iwl_mvm *mvm = IWL_MAC80211_GET_MVM(hw);
+	const struct iwl_fw *fw = mvm->fw;
+
+	skb = cfg80211_vendor_cmd_alloc_reply_skb(wiphy, sizeof(fw->fw_version));
+        if (!skb)
+                return -ENOMEM;
+        if (nla_put_string(skb, IWL_MVM_VENDOR_ATTR_FW_VER, fw->fw_version)) {
+                kfree_skb(skb);
+                return -ENOBUFS;
+	}
+
+	return cfg80211_vendor_cmd_reply(skb);
+}
+
+static int iwl_mvm_vendor_get_drv_version(struct wiphy *wiphy,
+				   struct wireless_dev *wdev,
+				   const void *data, int data_len)
+{
+	int err = 0;
+	struct sk_buff *skb;
+	struct ieee80211_hw *hw = wiphy_to_ieee80211_hw(wiphy);
+	struct iwl_mvm *mvm = IWL_MAC80211_GET_MVM(hw);
+	const struct iwl_fw *fw = mvm->fw;
+
+	skb = cfg80211_vendor_cmd_alloc_reply_skb(wiphy, sizeof(utsname()->release));
+        if (!skb)
+                return -ENOMEM;
+        if (nla_put_string(skb, IWL_MVM_VENDOR_ATTR_DRV_VER, utsname()->release)) {
+                kfree_skb(skb);
+                return -ENOBUFS;
+	}
+
+	return cfg80211_vendor_cmd_reply(skb);
+}
+
 static const struct wiphy_vendor_command iwl_mvm_vendor_commands[] = {
 	{
 		.info = {
@@ -2256,6 +2302,33 @@ static const struct wiphy_vendor_command iwl_mvm_vendor_commands[] = {
 		.maxattr = MAX_IWL_MVM_VENDOR_ATTR,
 #endif
 	},
+	{
+	.info = {
+			.vendor_id = INTEL_OUI,
+			.subcmd = IWL_MVM_VENDOR_CMD_GET_FW_VERSION,
+		},
+		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV |
+			 WIPHY_VENDOR_CMD_NEED_RUNNING,
+		.doit = iwl_mvm_vendor_get_fw_version,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = iwl_mvm_vendor_attr_policy,
+		.maxattr = MAX_IWL_MVM_VENDOR_ATTR,
+#endif
+	},
+	{
+		.info = {
+			.vendor_id = INTEL_OUI,
+			.subcmd = IWL_MVM_VENDOR_CMD_GET_DRV_VERSION,
+		},
+		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV |
+			 WIPHY_VENDOR_CMD_NEED_RUNNING,
+		.doit = iwl_mvm_vendor_get_drv_version,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = iwl_mvm_vendor_attr_policy,
+		.maxattr = MAX_IWL_MVM_VENDOR_ATTR,
+#endif
+	},
+
 };
 
 enum iwl_mvm_vendor_events_idx {


### PR DESCRIPTION
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Adding vendor command support for querying driver & firmware version 
from “projectceladon/vendor-intel-utils#885" to iwl7000 driver.

Tracked-On: OAM-99914
Signed-off-by: N V NandiniX <nandinix.n.v@intel.com>