### PR TITLE
ion_system_heap: support X86 archtecture

### DIFF
--- a/drivers/staging/android/ion/heaps/ion_system_heap.c
+++ b/drivers/staging/android/ion/heaps/ion_system_heap.c
@@ -137,6 +137,11 @@ static int ion_system_heap_allocate(struct ion_heap *heap,
 	sg = table->sgl;
 	list_for_each_entry_safe(page, tmp_page, &pages, lru) {
 		sg_set_page(sg, page, page_size(page), 0);
+#ifdef CONFIG_X86
+	if (!(buffer->flags & ION_FLAG_CACHED))
+		set_memory_wc((unsigned long)page_address(sg_page(sg)),
+				PAGE_ALIGN(sg->length) >> PAGE_SHIFT);
+#endif
 		sg = sg_next(sg);
 		list_del(&page->lru);
 	}
@@ -168,8 +173,14 @@ static void ion_system_heap_free(struct ion_buffer *buffer)
 	if (!(buffer->private_flags & ION_PRIV_FLAG_SHRINKER_FREE))
 		ion_buffer_zero(buffer);
 
-	for_each_sg(table->sgl, sg, table->nents, i)
+	for_each_sg(table->sgl, sg, table->nents, i){
+	#ifdef CONFIG_X86
+		if (!(buffer->flags & ION_FLAG_CACHED))
+			set_memory_wb((unsigned long)page_address(sg_page(sg)),
+					PAGE_ALIGN(sg->length) >> PAGE_SHIFT);
+	#endif
 		free_buffer_page(sys_heap, buffer, sg_page(sg));
+	}
 	sg_free_table(table);
 	kfree(table);
 }


### PR DESCRIPTION
we see tons of warning like:
[   45.846872] x86/PAT: NDK MediaCodec_:3753 map pfn RAM range req
write-combining for [mem 0x1e7a80000-0x1e7a87fff], got write-back
[   45.848827] x86/PAT: .vorbis.decoder:4088 map pfn RAM range req
write-combining for [mem 0x1e7a58000-0x1e7a58fff], got write-back
[   45.848875] x86/PAT: NDK MediaCodec_:3753 map pfn RAM range req
write-combining for [mem 0x1e7a48000-0x1e7a4ffff], got write-back
[   45.849403] x86/PAT: .vorbis.decoder:4088 map pfn RAM range
req write-combining for [mem 0x1e7a70000-0x1e7a70fff], got write-back

check the kernel Documentation/x86/pat.txt, it says:
A. Exporting pages to users with remap_pfn_range, io_remap_pfn_range,
vm_insert_pfn
Drivers wanting to export some pages to userspace do it by using
mmap interface and a combination of
1) pgprot_noncached()
2) io_remap_pfn_range() or remap_pfn_range() or vm_insert_pfn()
With PAT support, a new API pgprot_writecombine is being added.
So, drivers can continue to use the above sequence, with either
pgprot_noncached() or pgprot_writecombine() in step 1, followed by step 2.

In addition, step 2 internally tracks the region as UC or WC in
memtype list in order to ensure no conflicting mapping.

Note that this set of APIs only works with IO (non RAM) regions.
If driver ants to export a RAM region, it has to do set_memory_uc() or
set_memory_wc() as step 0 above and also track the usage of those pages
and use set_memory_wb() before the page is freed to free pool.

the fix follow the pat document, do set_memory_wc() as step 0 and
use the set_memory_wb() before the page is freed.

Tracked-On:
Signed-off-by: Tn, JyothiX <jyothix.tn@intel.com>